### PR TITLE
fix: device rediscovery issue when name changes

### DIFF
--- a/WiimotePair/ViewController.m
+++ b/WiimotePair/ViewController.m
@@ -95,6 +95,8 @@
 - (void)deviceInquiryDeviceFound:(IOBluetoothDeviceInquiry*)sender device:(IOBluetoothDevice*)device {
     // Skip unsupported devices.
     if (![device.name containsString:@"Nintendo RVL-CNT-01"]) {
+        // Clear devices to enable rediscovery if the name changes.
+        [_deviceInquiry clearFoundDevices];
         return;
     }
     


### PR DESCRIPTION
Fixes a bug where devices found with a different name were not processed when rediscovered with the correct name. The list of found devices is now cleared after each discovery, allowing for proper rediscovery.